### PR TITLE
Fix Installs on Pre 060

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">= 3.8.1"
 dependencies = [
-    "guardrails-ai>=0.4.0",
-    "guardrails-grhub-response_evaluator<1.0.0"
+    "guardrails-ai>=0.4.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
- Removed private pypi dependency in `main` branch until CI monkeypatches pyproject to include validator only for pypi version